### PR TITLE
mac os 'support'

### DIFF
--- a/R/rscodeio.R
+++ b/R/rscodeio.R
@@ -54,6 +54,9 @@ uninstall_theme <- function(){
 #' @export
 activate_menu_theme <- function() {
 
+  ## Styling menus not supported on Mac.
+  if(host_os_is_mac()) return(NULL)
+
   if(file.exists(gnome_theme_dark_backup()) |
      file.exists(windows_theme_dark_backup())) {
       message("RSCodeio menu theme already activated. Deactivate first.")
@@ -82,6 +85,9 @@ activate_menu_theme <- function() {
 #' @return nothing.
 #' @export
 deactivate_menu_theme <- function(){
+
+  ## Styling menus not supported on Mac.
+  if(host_os_is_mac()) return(NULL)
 
   if(!file.exists(gnome_theme_dark_backup()) |
      !file.exists(windows_theme_dark_backup())) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,8 @@
 get_rstudio_location <- function(){
+
+  ## This is the likely location for mac.
+  if(host_os_is_mac()) return("/Applications/RStudio.app/Contents")
+
   pandoc_dir <- Sys.getenv("RSTUDIO_PANDOC")
 
   dir_parts <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -24,3 +24,7 @@ windows_theme_dark <- function() {
 windows_theme_dark_backup <- function() {
   fs::path(get_rstudio_location(), "resources", "stylesheets","rstudio-windows-dark-rscodeio-backup.qss")
 }
+
+host_os_is_mac <- function(){
+  Sys.info()["sysname"] == "Darwin"
+}

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Get the package:
 remotes::install_github("anthonynorth/rscodeio")
 ```
 
-`rscodeio` modifies the theme of RStudio menus. These are not exposed by the current theming API and so this is achieved by modifying style sheets in the RStudio installation. To modify files in this area will likely require the installation to be run with administrator privelidges. To do this:
+`rscodeio` modifies the theme of RStudio menus. These are not exposed by the current theming API and so this is achieved by modifying style sheets in the RStudio installation. To modify files in this area will likely require the installation to be run with administrator privileges. To do this:
 
 * On Windows start RStudio by right clicking on a shortcut or menu icon and selecting 'Run as Administrator'
 * On Linux start RStudio in a terminal using `sudo rstudio --no-sandbox`
-* On Mac (? - Help Wanted)
+* On Mac this is not required. Theming the menus is not supported. 
+  - They're inherited from OS so might want to use your dark OS theme.
 
 From within RStudio running as administrator, run this command to install and apply the theme: 
 
@@ -32,7 +33,7 @@ Once installed it can also be selected using the RStudio theme picker in the usu
 
 # For best results
 
-- Enable: Tools -> Global Options -> Code -> Display -> Highligh R Function Calls 
+- Enable: Tools -> Global Options -> Code -> Display -> Highlight R Function Calls 
 - Enable: Tools -> Global Options -> Code -> Display -> Show Syntax Highlighting in Console
 - Enable: Tools -> Global Options -> Code -> Display -> Show Indent Guides
 - Enable: Tools -> Global Options -> Code -> Display -> Highlight Selected Line


### PR DESCRIPTION
Make the QT theme activate/deactivate do nothing on Mac OS. I think this should resolve #3 . Although we'll need a helper to test.

Also added a note about this to Mac section in README.