### PR TITLE
Tweak GNOME menu bar

### DIFF
--- a/inst/resources/rscodeio_tomorrow_night_bright.rstheme
+++ b/inst/resources/rscodeio_tomorrow_night_bright.rstheme
@@ -971,7 +971,7 @@
 }
 
 .rstudio-themes-flat .gwt-MenuItem-selected {
-  background-color: rgb(9, 71, 113) !important;
+  background-color: rgb(91, 91, 91) !important;
 }
 
 .rstudio-themes-flat .gwt-MenuItemSeparator > .menuSeparatorInner {

--- a/inst/resources/stylesheets/rstudio-gnome-dark.qss
+++ b/inst/resources/stylesheets/rstudio-gnome-dark.qss
@@ -1,7 +1,7 @@
 QMenuBar {
-  background-color: rgb(60, 60, 60);
+  background-color: rgb(37, 37, 37);
   color: rgb(204, 204, 204);
-  height: 30px;
+  height: 20px;
   font-size: 13px;
 }
 
@@ -15,7 +15,7 @@ QMenuBar::item:selected {
 }
 
 QMenu {
-  background-color: rgb(37, 37, 37);
+  background-color: rgb(62, 62, 62);
   color: rgb(204, 204, 204);
   font-size: 13px;
   padding: 6.5px 0;
@@ -24,7 +24,6 @@ QMenu {
 QMenu::item {
   height: 24px;
   padding: 0 26px;
-  border: 1px solid rgb(37, 37, 37);
 }
 
 QMenu::item:checked,

--- a/inst/resources/stylesheets/rstudio-gnome-dark.qss
+++ b/inst/resources/stylesheets/rstudio-gnome-dark.qss
@@ -36,7 +36,7 @@ QMenu::item:disabled {
 }
 
 QMenu::item:selected {
-  background-color: rgb(9, 71, 113);
+  background-color: rgb(91, 91, 91);
 }
 
 QMenu::item:selected:disabled {


### PR DESCRIPTION
### Menu bar tweaking

- Decrease height by 10px, saving vertical space.

- Use same background color as the rest of the menu bar and change drop-down color accordingly. This looks cleaner.

This is how the menu bar looks after the changes:

![Bildschirmfoto von 2020-10-16 00-08-14](https://user-images.githubusercontent.com/20040931/96191237-36149780-0f33-11eb-8a64-979a8bf67339.png)

### Drop-down menu tweaking

Additionally, the drop-down menu was adjusted to be consistent with the dark colors of Ubuntu's [Yaru theme](https://github.com/ubuntu/yaru#readme). Before, the menu background was the same as color as the editor background leading to bad visual discriminability and the highlighting was in blue.

Before:

![Bildschirmfoto von 2020-10-16 00-45-46](https://user-images.githubusercontent.com/20040931/96194942-fb166200-0f3a-11eb-92ce-bb064d6f69e0.png)

After:

![Bildschirmfoto von 2020-10-16 01-09-22](https://user-images.githubusercontent.com/20040931/96195274-db336e00-0f3b-11eb-83f3-7cc93f91dd64.png)
