### PR TITLE
Fix search bar styling

### DIFF
--- a/inst/resources/rscodeio.rstheme
+++ b/inst/resources/rscodeio.rstheme
@@ -453,7 +453,7 @@
 
 /* search input */
 .rstudio-themes-dark
-  :-webkit-any(.rstheme_toolbarWrapper, #rstudio_find_replace_bar)
+  :-webkit-any(.rstheme_toolbarWrapper, [id^="rstudio_find_replace_bar"])
   .search,
 .rstudio-themes-flat .themedPopupPanel .search {
   background-color: rgb(60, 60, 60) !important;

--- a/inst/resources/rscodeio_tomorrow_night_bright.rstheme
+++ b/inst/resources/rscodeio_tomorrow_night_bright.rstheme
@@ -903,7 +903,7 @@
 
 /* search input */
 .rstudio-themes-dark
-  :-webkit-any(.rstheme_toolbarWrapper, #rstudio_find_replace_bar)
+  :-webkit-any(.rstheme_toolbarWrapper, [id^="rstudio_find_replace_bar"])
   .search,
 .rstudio-themes-flat .themedPopupPanel .search {
   background-color: rgb(60, 60, 60) !important;


### PR DESCRIPTION
Only the first search bar will get the id `rstudio_find_replace_bar`, all the additional ones (in other document tabs) will get `rstudio_find_replace_bar_#` where `#` is an increasing number, so we have to take that into account.