### PR TITLE
Added support for Monaspace code ligatures

### DIFF
--- a/inst/resources/rscodeio.rstheme
+++ b/inst/resources/rscodeio.rstheme
@@ -45,6 +45,11 @@
   line-height: 1.3 !important;
 }
 
+.ace_scroller {
+  font-variant-ligatures: discretionary-ligatures;
+  font-feature-settings: "dlig", "calt" 1;
+}
+
 .ace_cursor {
   border-color: rgb(174, 175, 173);
   width: 2px;

--- a/inst/resources/rscodeio_tomorrow_night_bright.rstheme
+++ b/inst/resources/rscodeio_tomorrow_night_bright.rstheme
@@ -111,6 +111,10 @@
 .ace_support.ace_type {
   color: #E7C547
 }
+.ace_scroller {
+  font-variant-ligatures: discretionary-ligatures;
+  font-feature-settings: "dlig", "calt" 1;
+}
 .ace_heading,
 .ace_markup.ace_heading,
 .ace_string {


### PR DESCRIPTION
Added support for [Monaspace](https://monaspace.githubnext.com/) code ligatures to both .rstheme files. Added "dlig" and "calt" ligature sets. Tested on macOS. 

Usage requires installing the font, then selecting a member of the Monaspace family in the RStudio options.